### PR TITLE
Fix potentially inadvertently broken -include directive

### DIFF
--- a/src/wsc_lib.erl
+++ b/src/wsc_lib.erl
@@ -4,7 +4,7 @@
 %% Purely functional aspects of websocket client comms.
 %%
 %% Herein live all the functions for pure data processing.
--include("src/websocket_req.hrl").
+-include("websocket_req.hrl").
 
 -export([create_auth_header/3]).
 -export([create_handshake/2]).


### PR DESCRIPTION
Don't remember why it was different in this file but it causes compilation errors when used as a dep under rebar3