### PR TITLE
Allow keepalive opt for `websocket_client:start_link/4` invocation

### DIFF
--- a/test/echo_server.erl
+++ b/test/echo_server.erl
@@ -53,6 +53,9 @@ websocket_init(_Transport, Req, _Opts) ->
             {shutdown, Req3}
     end.
 
+websocket_handle({ping, Payload}=_Frame, Req, State) ->
+    ct:pal("~p pingpong with size ~p~n", [?MODULE, byte_size(Payload)]),
+    {ok, Req, State};
 websocket_handle({Type, Payload}=Frame, Req, State) ->
     ct:pal("~p replying with ~p of size ~p~n", [?MODULE, Type, byte_size(Payload)]),
     {reply, Frame, Req, State}.

--- a/test/ws_client.erl
+++ b/test/ws_client.erl
@@ -5,6 +5,7 @@
 -export([
          start_link/0,
          start_link/1,
+         start_link/2,
          send_text/2,
          send_binary/2,
          send_ping/2,
@@ -35,6 +36,9 @@ start_link() ->
 
 start_link(Url) ->
     {ok, _} = websocket_client:start_link(Url, ?MODULE, [self()]).
+
+start_link(Url, KeepAlive) ->
+    {ok, _} = websocket_client:start_link(Url, ?MODULE, [self()], [{keepalive, KeepAlive}]).
 
 stop(Pid) ->
     Pid ! stop.


### PR DESCRIPTION
Stash the option value if passed, in the `#websocket_req{}` Set up an
`erlang:send_after/3` based on that value during connect phase Override it
if the handler later provides it in `onconnect/2` return

Fixes #11