### PR TITLE
Add process registration

### DIFF
--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -130,20 +130,22 @@ start_link(URL, Handler, HandlerArgs, Opts) ->
 %%  Name = atom()
 %%  GlobalName = ViaName = term()
 %%  Module = atom()
+start_link(FsmName, URL, Handler, HandlerArgs, Opts) when is_binary(URL) ->
+  start_link(FsmName, binary_to_list(URL), Handler, HandlerArgs, Opts);
 start_link(FsmName, URL, Handler, HandlerArgs, Opts) when is_list(Opts) ->
     case http_uri:parse(URL, [{scheme_defaults, [{ws,80},{wss,443}]}]) of
         {ok, {Protocol, _, Host, Port, Path, Query}} ->
             InitArgs = [Protocol, Host, Port, Path ++ Query, Handler, HandlerArgs, Opts],
             %FsmOpts = [{dbg, [trace]}],
             FsmOpts = [],
-            start_link0(FsmName, InitArgs, FsmOpts);
+            fsm_start_link(FsmName, InitArgs, FsmOpts);
         {error, _} = Error ->
             Error
     end.
 
-start_link0(undefined, Args, Options) ->
+fsm_start_link(undefined, Args, Options) ->
     gen_fsm:start_link(?MODULE, Args, Options);
-start_link0(FsmName, Args, Options) ->
+fsm_start_link(FsmName, Args, Options) ->
     gen_fsm:start_link(FsmName, ?MODULE, Args, Options).
 
 send(Client, Frame) ->

--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -10,6 +10,7 @@
 
 -export([start_link/3]).
 -export([start_link/4]).
+-export([start_link/5]).
 -export([cast/2]).
 -export([send/2]).
 
@@ -120,16 +121,30 @@ start_link(URL, Handler, Args) ->
 %% (useful if you need to add an e.g. 'Origin' header on connection.
 %%  - {ssl_verify, verify_none | verify_peer | {verify_fun, _}} : this is passed
 %%  through to ssl:connect/2,3.
-start_link(URL, Handler, HandlerArgs, Opts) when is_list(Opts) ->
+start_link(URL, Handler, HandlerArgs, Opts) ->
+    start_link(undefined, URL, Handler, HandlerArgs, Opts).
+
+%% @doc Start the websocket client
+%% see gen_fsm:start_link(FsmName, Module, Args, Options)
+%% FsmName = {local,Name} | {global,GlobalName} | {via,Module,ViaName}
+%%  Name = atom()
+%%  GlobalName = ViaName = term()
+%%  Module = atom()
+start_link(FsmName, URL, Handler, HandlerArgs, Opts) when is_list(Opts) ->
     case http_uri:parse(URL, [{scheme_defaults, [{ws,80},{wss,443}]}]) of
         {ok, {Protocol, _, Host, Port, Path, Query}} ->
             InitArgs = [Protocol, Host, Port, Path ++ Query, Handler, HandlerArgs, Opts],
             %FsmOpts = [{dbg, [trace]}],
             FsmOpts = [],
-            gen_fsm:start_link(?MODULE, InitArgs, FsmOpts);
+            start_link0(FsmName, InitArgs, FsmOpts);
         {error, _} = Error ->
             Error
     end.
+
+start_link0(undefined, Args, Options) ->
+    gen_fsm:start_link(?MODULE, Args, Options);
+start_link0(FsmName, Args, Options) ->
+    gen_fsm:start_link(FsmName, ?MODULE, Args, Options).
 
 send(Client, Frame) ->
     gen_fsm:sync_send_event(Client, {send, Frame}).


### PR DESCRIPTION
This request handles a couple of issues:

  -- Added a new start_link function to register the websocket_client process, as in gen_fsm:start_link/4, so other processes can send messages to it.

  -- Fixed the start_link function to handle binary URL.