### PR TITLE
add option to reconnect after a given interval

### DIFF
--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -280,6 +280,9 @@ disconnect(Reason, #context{
         {reconnect, HState1} ->
             ok = gen_fsm:send_event(self(), connect),
             {next_state, disconnected, Context#context{handler={Handler, HState1}}};
+        {reconnect, Interval, HState1} ->
+            gen_fsm:send_event_after(Interval, connect),
+            {next_state, disconnected, Context#context{handler={Handler, HState1}}};
         {close, Reason1, HState1} ->
             ok = websocket_close(WSReq0, Handler, HState1, Reason1),
             {stop, Reason1, Context#context{handler={Handler, HState1}}}


### PR DESCRIPTION
This pr adds support to reconnect only after a given interval by returning a proper value in the `ondisconnect` callback (e.g. by returning `{reconnect, 5000, State}`.

This also allows users to implement an exponential backoff delay for reconnections by keeping track of the number of attempts using the `onconnect` and `ondisconnect` callbacks.