### PR TITLE
crypto rand_bytes deprecated. use strong_rand_bytes

### DIFF
--- a/src/wsc_lib.erl
+++ b/src/wsc_lib.erl
@@ -168,7 +168,7 @@ encode_frame({Type, Payload}) ->
     Opcode = websocket_req:name_to_opcode(Type),
     Len = iolist_size(Payload),
     BinLen = payload_length_to_binary(Len),
-    MaskingKeyBin = crypto:rand_bytes(4),
+    MaskingKeyBin = crypto:strong_rand_bytes(4),
     << MaskingKey:32 >> = MaskingKeyBin,
     Header = << 1:1, 0:3, Opcode:4, 1:1, BinLen/bits, MaskingKeyBin/bits >>,
     MaskedPayload = mask_payload(MaskingKey, Payload),
@@ -224,4 +224,4 @@ set_continuation_if_empty(WSReq, Opcode) ->
 %% @doc Key sent in initial handshake
 -spec generate_ws_key() -> binary().
 generate_ws_key() ->
-    base64:encode(crypto:rand_bytes(16)).
+    base64:encode(crypto:strong_rand_bytes(16)).


### PR DESCRIPTION
Hi :smile: 
A library that I was using (elixir-slack) that uses your package from hex.pm stopped working because looks like rand_bytes function got deprecated and it doesn't work anymore.
This seems to fix it. I did the same they have done in the original fork
https://github.com/jeremyong/websocket_client/pull/48
Do you mind updating hex.pm package?

Thanks a lot!