### PR TITLE
Add echo_proxy

### DIFF
--- a/test/echo_proxy.erl
+++ b/test/echo_proxy.erl
@@ -1,0 +1,118 @@
+-module(echo_proxy).
+
+-export([listen/0]).
+%% A single process that waits to receive an inbound connection on
+%% port 8081. Upon receipt of connection, it makes an outbound connection
+%% to port 8080 and forwards all traffic back and forth.
+%%
+%% TODO: Sniff traffic
+%% TODO: Decode/Decrypt traffic and print
+%% TODO: Filter according to ~rules
+%%
+
+-define(TCP_OPTS,
+        [binary, {active, false}, {packet, 0}, {reuseaddr, true}]).
+listen() ->
+    {ok, LSock} = gen_tcp:listen(8081, ?TCP_OPTS),
+    accept(LSock).
+
+accept(LSock) ->
+    {ok, Sock} = gen_tcp:accept(LSock),
+    {ok, OutSock} = gen_tcp:connect("localhost", 8080, ?TCP_OPTS),
+    error_logger:info_msg("Handling connection"),
+    Pid = spawn(fun() -> handshake(Sock, OutSock) end),
+    ok = gen_tcp:controlling_process(Sock, Pid),
+    ok = gen_tcp:controlling_process(OutSock, Pid),
+    accept(LSock).
+
+handshake(InSock, OutSock) ->
+    %% 
+    %% Set both sockets active
+    inet:setopts(InSock, [{active, true}]),
+    inet:setopts(OutSock, [{active, true}]),
+    receive
+        {tcp, InSock, Data} ->
+            ok = gen_tcp:send(OutSock, Data),
+            {ok, {_ethod, Path, Headers}} = decode_request(Data),
+            %% TODO Handle some other error cases
+            case lists:keyfind("Sec-Websocket-Key", 1, Headers) of
+                false ->
+                    error_logger:info_msg("No WS Key found in headers"),
+                    handshake(InSock, OutSock);
+                {"Sec-Websocket-Key", Key} ->
+                    error_logger:info_msg("Client used key ~p", [Key]),
+                    WSReq = websocket_req:new(
+                              ws, "localhost", 8081,
+                              Path, InSock, gen_tcp,
+                              list_to_binary(Key)),
+                    validate_handshake(WSReq, InSock, OutSock)
+            end
+    end.
+
+validate_handshake(WSReq, InSock, OutSock) ->
+    receive
+        {tcp, OutSock, Data} ->
+            case wsc_lib:validate_handshake(Data, websocket_req:key(WSReq)) of
+                {ok, _} ->
+                    error_logger:info_msg("[Server] Confirmed handshake"),
+                    ok = gen_tcp:send(InSock, Data),
+                    loop(WSReq, InSock, OutSock);
+                Other ->
+                    error_logger:info_msg("[Server] failed handshake: ~p", [Other]),
+                    {error, Other}
+            end
+    end.
+
+%% TODO Processing frames go here
+handle_frame("Server", _, _, {frame, {pong, Foo}, _, <<>>}) ->
+    error_logger:info_msg("[Server] {pong, ~s} BLOCKED", [Foo]),
+    ok;
+handle_frame(Name, DstSock, RawData, {frame, Decoded, _, Rest}) ->
+    error_logger:info_msg("[~s]: ~p ~p~n", [Name, Decoded, Rest]),
+    gen_tcp:send(DstSock, RawData).
+
+loop(WSReq, InSock, OutSock) ->
+    %% 
+    %% Set both sockets active
+    inet:setopts(InSock, [{active, true}]),
+    inet:setopts(OutSock, [{active, true}]),
+    receive
+        {tcp, InSock, Data} ->
+            handle_frame("Client", OutSock, Data, wsc_lib:decode_frame(WSReq, Data)),
+            loop(WSReq, InSock, OutSock);
+        {tcp, OutSock, Data} ->
+            handle_frame("Server", InSock, Data, wsc_lib:decode_frame(WSReq, Data)),
+            loop(WSReq, InSock, OutSock);
+        {tcp_closed, InSock} ->
+            error_logger:info_msg("[Client:Closed]"),
+            gen_tcp:close(OutSock),
+            (catch gen_tcp:close(InSock)),
+            ok;
+        {tcp_closed, OutSock} ->
+            error_logger:info_msg("[Server:Closed]"),
+            gen_tcp:close(InSock),
+            (catch gen_tcp:close(OutSock)),
+            ok
+    end.
+
+decode_request(Data) ->
+    case erlang:decode_packet(http, Data, []) of
+        {ok, {http_request, Method, Path, _ersion}, Request} ->
+            {ok, Headers} = decode_headers(Request, []),
+            {ok, {Method, Path, Headers}};
+        Other -> {error, Other}
+    end.
+decode_headers(Data, Acc) ->
+    case erlang:decode_packet(httph, Data, []) of
+        {ok, {http_header, _, K, _, V}, Rest} ->
+            error_logger:info_msg("Client sent ~p(~p)", [K, V]),
+            decode_headers(Rest, [{K, V} | Acc]);
+        {ok, http_eoh, <<>>} ->
+            {ok, Acc};
+        {ok, {http_error, Reason}, Rest} ->
+            %% TODO If we hit this, remove the first "\n" from Data and try again
+            {error, {http_error, Reason, Rest}}
+    end.
+
+
+

--- a/test/echo_proxy.erl
+++ b/test/echo_proxy.erl
@@ -5,8 +5,6 @@
 %% port 8081. Upon receipt of connection, it makes an outbound connection
 %% to port 8080 and forwards all traffic back and forth.
 %%
-%% TODO: Sniff traffic
-%% TODO: Decode/Decrypt traffic and print
 %% TODO: Filter according to ~rules
 %%
 

--- a/test/echo_server.erl
+++ b/test/echo_server.erl
@@ -18,14 +18,16 @@
 -record(state, {}).
 
 start() ->
-    ct:pal("Starting ~p.~n", [?MODULE]),
+    Port = 8080,
+    {ok, _} = application:ensure_all_started(cowboy),
+    error_logger:info_msg("Starting ~p on port ~b.~n", [?MODULE, Port]),
     Dispatch = cowboy_router:compile([{'_', [
                                              {"/hello", ?MODULE, []},
                                              {'_', ?MODULE, []}
                                             ]}]),
     {ok, _} = cowboy:start_http(echo_listener, 2, [
                                                    {nodelay, true},
-                                                   {port, 8080},
+                                                   {port, Port},
                                                    {max_connections, 100}
                                                   ],
                                 [{env, [{dispatch, Dispatch}]}]).
@@ -48,27 +50,27 @@ websocket_init(_Transport, Req, _Opts) ->
             end;
         {Code, Req2} ->
             IntegerCode = list_to_integer(binary_to_list(Code)),
-            ct:pal("~p shuting down on init using '~p' status code~n", [?MODULE, IntegerCode]),
+            error_logger:info_msg("~p shuting down on init using '~p' status code~n", [?MODULE, IntegerCode]),
             {ok, Req3} = cowboy_req:reply(IntegerCode, Req2),
             {shutdown, Req3}
     end.
 
 websocket_handle({ping, Payload}=_Frame, Req, State) ->
-    ct:pal("~p pingpong with size ~p~n", [?MODULE, byte_size(Payload)]),
+    error_logger:info_msg("~p pingpong with size ~p~n", [?MODULE, byte_size(Payload)]),
     {ok, Req, State};
 websocket_handle({Type, Payload}=Frame, Req, State) ->
-    ct:pal("~p replying with ~p of size ~p~n", [?MODULE, Type, byte_size(Payload)]),
+    error_logger:info_msg("~p replying with ~p of size ~p~n", [?MODULE, Type, byte_size(Payload)]),
     {reply, Frame, Req, State}.
 
 websocket_info({send, Text}, Req, State) ->
     timer:sleep(1),
-    ct:pal("~p sent frame of size ~p ~n", [?MODULE, byte_size(Text)]),
+    error_logger:info_msg("~p sent frame of size ~p ~n", [?MODULE, byte_size(Text)]),
     {reply, {text, Text}, Req, State};
 
 websocket_info(_Msg, Req, State) ->
-    ct:pal("~p received OoB msg: ~p~n", [?MODULE, _Msg]),
+    error_logger:info_msg("~p received OoB msg: ~p~n", [?MODULE, _Msg]),
     {ok, Req, State}.
 
 websocket_terminate(Reason, _Req, _State) ->
-    ct:pal("~p terminating with reason ~p~n", [?MODULE, Reason]),
+    error_logger:info_msg("~p terminating with reason ~p~n", [?MODULE, Reason]),
     ok.

--- a/test/wc_SUITE.erl
+++ b/test/wc_SUITE.erl
@@ -138,7 +138,7 @@ test_keepalive_opt(_) ->
     ok.
 
 test_keepalive_timeout(_) ->
-    {ok, S} = gen_tcp:listen(9090, [binary, {packet, 0}, {active, true}]),
+    {ok, _} = gen_tcp:listen(9090, [binary, {packet, 0}, {active, true}]),
     process_flag(trap_exit, true),
     {ok, C} = ws_client:start_link("ws://localhost:9090", 500),
     receive


### PR DESCRIPTION
A module to help with testing: echo_proxy can sit between client and server,
using a custom function to filter and process messages as they are passed
between the entities. Default behaviour is to block `pong` packets.