### PR TITLE
Fix missing kernel, stdlib application warning

### DIFF
--- a/src/websocket_client.app.src
+++ b/src/websocket_client.app.src
@@ -2,7 +2,7 @@
              [{description,"Erlang websocket client"},
               {vsn,"1.4.0"},
               {registered,[]},
-              {applications,[ssl,crypto,inets]},
+              {applications,[kernel,stdlib,ssl,crypto,inets]},
               {env,[]},
               {modules,[]},
               {licenses,["MIT"]}]}.


### PR DESCRIPTION
This fixes the following warning when building websocket_client:

```
===> Compiling websocket_client
===> "deps/websocket_client/ebin/websocket_client.app" is missing kernel from applications list
===> "deps/websocket_client/ebin/websocket_client.app" is missing stdlib from applications list
```