### PR TITLE
Only download coveralls on CI

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,13 +1,10 @@
 {profiles, [
     {test,
-     [ {deps, [ 
+     [ {deps, [
                {cowboy, "1.1.2"}, recon,
                { proper, {git, "https://github.com/manopapad/proper.git", {tag, "v1.2"}} }
               ] } ]}
     ]}.
 
-{plugins, [{coveralls, {git, "https://github.com/markusn/coveralls-erl", {ref, "57a190502cd2606d2b5cc142bd5cec1ec7c497b2"}}}]}.
 {cover_enabled, true}.
 {cover_export_enabled, true}.
-{coveralls_coverdata, "_build/test/cover/ct.coverdata"}.
-{coveralls_service_name, "travis-ci"}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,9 +1,12 @@
 %%% -*- mode: erlang -*-
 
-case os:getenv("TRAVIS") of
-    "true" ->
-        JobId   = os:getenv("TRAVIS_JOB_ID"),
-        lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId});
-    _ ->
-        CONFIG
+case os:getenv("TRAVIS_JOB_ID") of
+    false -> CONFIG;
+    JobId ->
+        [{plugins, [coveralls]},
+         {coveralls_coverdata, "_build/test/cover/ct.coverdata"},
+         {coveralls_service_name, "travis-ci"},
+         {coveralls_service_job_id, JobId}
+         | CONFIG
+        ]
 end.


### PR DESCRIPTION
This makes the coveralls check optional when normalling building. It
removes the following lines from being printed when compiling projects
that depend on it:

```
===> Fetching coveralls (from
{git,"https://github.com/markusn/coveralls-erl",
                     {ref,"57a190502cd2606d2b5cc142bd5cec1ec7c497b2"}})
===> Compiling coveralls
_build/default/plugins/coveralls/src/coveralls.erl:103: Warning:
random:uniform/1: the 'random' module is deprecated; use the 'rand'
module instead

```

It also bumps coveralls to use the version stored on hex since the
specified version seemed pretty old.