### PR TITLE
Remove "foo" from keep-alive payload

### DIFF
--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -424,7 +424,7 @@ handle_keepalive(KAState, #context{ wsreq=WSReq, ka_attempts=KAAttempts }=Contex
         _ ->
             % case encode_and_send({ping, <<"foo">>}, WSReq) of
             %     ok ->
-            ok = encode_and_send({ping, <<"foo">>}, WSReq),
+            ok = encode_and_send(ping, WSReq),
                     NewTimer = erlang:send_after(KeepAlive, self(), keepalive),
                     WSReq1 = websocket_req:set([{keepalive_timer, NewTimer}], WSReq),
                     {next_state, KAState, Context#context{wsreq=WSReq1, ka_attempts=(KAAttempts+1)}}%%;

--- a/test/wc_SUITE.erl
+++ b/test/wc_SUITE.erl
@@ -137,7 +137,7 @@ test_bad_request(_) ->
 test_keepalive_opt(_) ->
     {ok, Pid} = ws_client:start_link("ws://localhost:8080", 100),
     receive {ok, Pid} -> ok after 500 -> ct:fail(timeout) end,
-    {pong, <<"foo">>} = ws_client:recv(Pid, 500),
+    {pong, <<>>} = ws_client:recv(Pid, 500),
     ws_client:stop(Pid),
     ok.
 


### PR DESCRIPTION
Really simple optimization to decrease the size of the keep-alive messages for those that might be more bandwidth conscience

/cc @fhunleth