### PR TITLE
Support OTP 25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
     strategy:
       matrix:
-        otp: ['22', '23', '24']
+        otp: ['22', '23', '24', '25']
         rebar3: ['3.18.0']
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: erlang
 otp_release:
-  - 21.3.8
+  - 25.0
+  - 24.3.4.1
+  - 23.3.4.14
   - 22.3.2
+  - 21.3.8
 
 install: wget https://github.com/erlang/rebar3/releases/download/3.13.1/rebar3 && chmod 755 rebar3
 


### PR DESCRIPTION
This MR replaces `http_uri.parse/1` (removed in OTP 25) with `uri_string.parse/1` (introduced in OTP 21).  Additionally, this also expands the tested OTP versions in Travis CI to include OTP 23, 24, and 25 to ensure the use of `uri_string.parse/1` doesn't break anything. Fixes #72.