### PR TITLE
Ensure transport closed info is always handled properly

### DIFF
--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -310,6 +310,11 @@ disconnect(Reason, #context{
             {stop, Reason1, Context#context{handler={Handler, HState1}}}
     end.
 
+disconnected(info, {TransClosed, _Sock},
+          #context{
+             transport=#transport{ closed=TransClosed } %% NB: matched
+            }=Context) ->
+    disconnect({remote, closed}, Context);
 disconnected(info, Msg, Context) ->
     handle_info(Msg, Context);
 disconnected(internal, connect, Context0) ->

--- a/test/ws_client.erl
+++ b/test/ws_client.erl
@@ -11,6 +11,7 @@
          send_text/2,
          send_binary/2,
          send_ping/2,
+         send_close/1,
          sync_send_text/2,
          sync_send_binary/2,
          sync_send_ping/2,
@@ -63,6 +64,9 @@ send_binary(Pid, Msg) ->
 
 send_ping(Pid, Msg) ->
     websocket_client:cast(Pid, {ping, Msg}).
+
+send_close(Pid) ->
+    websocket_client:cast(Pid, close).
 
 sync_send_text(Pid, Msg) ->
     websocket_client:send(Pid, {text, Msg}).


### PR DESCRIPTION
This PR restores the behavior prior to 1.4.0, where arriving `tcp_closed` info triggers `ondisconnect/2` callback regardless of the client's state.

#### Problem

In versions 1.4.0 and later, the `ondisconnect/2` callback is only triggered in the `connected` and `handshaking` states.
This change prevents the callback from being invoked if `tcp_closed` info arrives after receiving a Close frame.

#### Additional Explanation

While it may seem counterintuitive to expect `tcp_closed` info in the `disconnected` state, this happens because the client enters the `disconnected` state after receiving a Close frame (and before the connection is actually closed).

An ideal approach might be introducing a new state, which partially corresponds to the CLOSING state stated in RFC 6455 (related to #17).
However, since such change should be done in accordance with #62, I chose to restore the previous behavior.