### PR TITLE
Handle errors returned by ping gracefully

### DIFF
--- a/src/websocket_client.erl
+++ b/src/websocket_client.erl
@@ -444,15 +444,14 @@ handle_keepalive(KAState, #context{ wsreq=WSReq, ka_attempts=KAAttempts }=Contex
         KAMax->
             disconnect({error, keepalive_timeout}, Context);
         _ ->
-            % case encode_and_send({ping, <<"foo">>}, WSReq) of
-            %     ok ->
-            ok = encode_and_send(ping, WSReq),
+            case encode_and_send(ping, WSReq) of
+                ok ->
                     NewTimer = erlang:send_after(KeepAlive, self(), keepalive),
                     WSReq1 = websocket_req:set([{keepalive_timer, NewTimer}], WSReq),
                     {next_state, KAState, Context#context{wsreq=WSReq1, ka_attempts=(KAAttempts+1)}}%%;
-                % {error, _} = Reason ->
-                %     disconnect(Reason, Context)
-            % end
+                {error, _} = Reason ->
+                    disconnect(Reason, Context)
+            end
                     
     end.
 


### PR DESCRIPTION
I was investigating some errors on our system, probably caused by a sudden disconnect, and stumbled upon this code. I thought it would be cleaner to handle the error more graceful and remove/reuse the commented code.